### PR TITLE
Support case insensitive commands

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -62,7 +62,7 @@ for (var comment of parsed) {
 }
 
 // get the selected command from the dictionary and execute it
-var requested = commands[command];
+var requested = commands[command.toLowerCase()];
 // if not found, show some variation on help
 // "legsican-client help" also conveniently triggers this since there's no client.help()
 if (!requested) {


### PR DESCRIPTION
The parsed commands are all lowercase but the commands listed under the help command are not. This change lowercases the command to make the case agnostic.